### PR TITLE
Add player and game list sockets

### DIFF
--- a/handlers/createGame.go
+++ b/handlers/createGame.go
@@ -13,8 +13,8 @@ type CreateGameResponse struct {
 }
 
 func CreateGameHandler() http.HandlerFunc {
-	return util.BuildHandler(nil, func(w http.ResponseWriter, queries util.QueryExtractor) {
-		name, err := queries.Query("name")
+	return util.BuildHandler(nil, func(w http.ResponseWriter, r *http.Request) {
+		name, err := util.GetQuery(r, "name")
 
 		if err != nil {
 			util.LogInternalError(w, err)

--- a/handlers/createPlayer.go
+++ b/handlers/createPlayer.go
@@ -14,8 +14,8 @@ type CreatePlayerResponse struct {
 }
 
 func CreatePlayerHandler() http.HandlerFunc {
-	return util.BuildHandler(nil, func(w http.ResponseWriter, queries util.QueryExtractor) {
-		gameId, err := queries.Query("game_id")
+	return util.BuildHandler(nil, func(w http.ResponseWriter, r *http.Request) {
+		gameId, err := util.GetQuery(r, "game_id")
 
 		if err != nil {
 			util.LogInternalError(w, err)
@@ -29,7 +29,7 @@ func CreatePlayerHandler() http.HandlerFunc {
 			return
 		}
 
-		playerName, err := queries.Query("name")
+		playerName, err := util.GetQuery(r, "name")
 
 		if err != nil {
 			util.LogInternalError(w, err)
@@ -48,6 +48,6 @@ func CreatePlayerHandler() http.HandlerFunc {
 			Game: *game,
 		})
 
-		fmt.Printf("\nCreated game %s with playerId %s", playerName, player.Id)
+		fmt.Printf("\nCreated player %s with playerId %s", playerName, player.Id)
 	})
 }

--- a/handlers/dealCards.go
+++ b/handlers/dealCards.go
@@ -13,8 +13,8 @@ type DealCardsResponse struct {
 }
 
 func DealCardsHandler() http.HandlerFunc {
-	return util.BuildHandler(nil, func(w http.ResponseWriter, queries util.QueryExtractor) {
-		gameId, err := queries.Query("game_id")
+	return util.BuildHandler(nil, func(w http.ResponseWriter, r *http.Request) {
+		gameId, err := util.GetQuery(r, "game_id")
 
 		if err != nil {
 			util.LogInternalError(w, err)

--- a/handlers/deleteGame.go
+++ b/handlers/deleteGame.go
@@ -8,8 +8,8 @@ import (
 )
 
 func DeleteGameHandler() http.HandlerFunc {
-	return util.BuildHandler(nil, func(w http.ResponseWriter, queries util.QueryExtractor) {
-		gameId, err := queries.Query("game_id")
+	return util.BuildHandler(nil, func(w http.ResponseWriter, r *http.Request) {
+		gameId, err := util.GetQuery(r, "game_id")
 
 		if err != nil {
 			util.LogInternalError(w, err)

--- a/handlers/deletePlayer.go
+++ b/handlers/deletePlayer.go
@@ -17,15 +17,15 @@ type DeletePlayerResponse struct {
 }
 
 func DeletePlayerHandler() http.HandlerFunc {
-	return util.BuildHandler(nil, func(w http.ResponseWriter, queries util.QueryExtractor) {
-		gameId, err := queries.Query("game_id")
+	return util.BuildHandler(nil, func(w http.ResponseWriter, r *http.Request) {
+		gameId, err := util.GetQuery(r, "game_id")
 
 		if err != nil {
 			util.LogInternalError(w, err)
 			return
 		}
 
-		playerId, err := queries.Query("player_id")
+		playerId, err := util.GetQuery(r, "player_id")
 
 		if err != nil {
 			util.LogInternalError(w, err)

--- a/handlers/getGame.go
+++ b/handlers/getGame.go
@@ -9,8 +9,8 @@ import (
 )
 
 func GetGameHandler() http.HandlerFunc {
-	return util.BuildHandler(nil, func(w http.ResponseWriter, queries util.QueryExtractor) {
-		gameId, err := queries.Query("game_id")
+	return util.BuildHandler(nil, func(w http.ResponseWriter, r *http.Request) {
+		gameId, err := util.GetQuery(r, "game_id")
 
 		if err != nil {
 			util.LogInternalError(w, err)

--- a/handlers/getGames.go
+++ b/handlers/getGames.go
@@ -9,7 +9,7 @@ import (
 )
 
 func GetGamesHandler() http.HandlerFunc {
-	return util.BuildHandler(nil, func(w http.ResponseWriter, _ util.QueryExtractor) {
+	return util.BuildHandler(nil, func(w http.ResponseWriter, r *http.Request) {
 		err := json.NewEncoder(w).Encode(truco.Games)
 
 		if err != nil {

--- a/handlers/playCard.go
+++ b/handlers/playCard.go
@@ -18,15 +18,15 @@ type PlayCardResponse  struct {
 
 func PlayCardHandler() http.HandlerFunc {
 	request := PlayCardRequest{}
-	return util.BuildHandler(&request, func(w http.ResponseWriter, queries util.QueryExtractor) {
-		gameId, err := queries.Query("game_id")
+	return util.BuildHandler(&request, func(w http.ResponseWriter, r *http.Request) {
+		gameId, err := util.GetQuery(r, "game_id")
 
 		if err != nil {
 			util.LogInternalError(w, err)
 			return
 		}
 
-		playerId, err := queries.Query("player_id")
+		playerId, err := util.GetQuery(r, "player_id")
 
 		if err != nil {
 			util.LogInternalError(w, err)

--- a/handlers/sockets/getGameListSocket.go
+++ b/handlers/sockets/getGameListSocket.go
@@ -1,0 +1,56 @@
+package sockets
+
+import (
+	"github.com/bkach/truco/handlers/util"
+	"github.com/bkach/truco/truco"
+	"github.com/gorilla/websocket"
+	"net/http"
+)
+
+type GameListResponse struct {
+	Games []GameListResponseGame `json:"games"`
+}
+
+type GameListResponseGame struct {
+	GameId   string `json:"game_id"`
+	GameName string `json:"name"`
+}
+
+func GetGameListSocketHandler() http.HandlerFunc {
+	onConnect := func(w http.ResponseWriter, r *http.Request, conn *websocket.Conn) {
+		truco.RegisterGameListChangeListener(
+			conn.RemoteAddr().String(),
+			gameListChangeListener(conn),
+		)
+	}
+
+	onDisconnect := func(w http.ResponseWriter, r *http.Request, conn *websocket.Conn) {
+		truco.RemoveGameListChangeListener(conn.RemoteAddr().String())
+	}
+
+	return util.BuildSocketHandler(onConnect, onDisconnect)
+}
+
+func gameListChangeListener(conn *websocket.Conn) func() {
+	return func() {
+		var responseGames []GameListResponseGame
+		for _, game := range truco.Games {
+			responseGames = append(responseGames, GameListResponseGame{
+				GameId:   game.Id,
+				GameName: game.Name,
+			})
+		}
+
+		response := GameListResponse{
+			Games: responseGames,
+		}
+
+		err := conn.WriteJSON(response)
+
+		if err != nil {
+			util.LogSocketErrorAndCloseConnection(conn, err)
+			return
+		}
+	}
+}
+

--- a/handlers/sockets/getPlayerListSocket.go
+++ b/handlers/sockets/getPlayerListSocket.go
@@ -1,0 +1,61 @@
+package sockets
+
+import (
+	"github.com/bkach/truco/handlers/util"
+	"github.com/bkach/truco/truco"
+	"github.com/gorilla/websocket"
+	"net/http"
+)
+
+type PlayerListResponse struct {
+	Player []truco.Player `json:"players"`
+}
+
+func GetPlayerListSocketHandler() http.HandlerFunc {
+	onConnect := func(w http.ResponseWriter, r *http.Request, conn *websocket.Conn) {
+		gameId, err := util.GetQuery(r, "game_id")
+
+		if err != nil {
+			util.LogSocketErrorAndCloseConnection(conn, err)
+			return
+		}
+
+		_, _, err = truco.FindGameWithId(gameId)
+
+		if err != nil {
+			util.LogSocketErrorAndCloseConnection(conn, err)
+			return
+		}
+
+		truco.RegisterPlayerListChangeListener(
+			conn.RemoteAddr().String(),
+			gameId,
+			playerListChangeListener(gameId, conn),
+		)
+	}
+
+	onDisconnect := func(w http.ResponseWriter, r *http.Request, conn *websocket.Conn) {
+		truco.RemovePlayerListChangeListener(conn.RemoteAddr().String())
+	}
+
+	return util.BuildSocketHandler(onConnect, onDisconnect)
+}
+
+func playerListChangeListener(gameId string, conn *websocket.Conn) func() {
+	return func() {
+		_, game, err := truco.FindGameWithId(gameId)
+
+		if err != nil {
+			util.LogSocketErrorAndCloseConnection(conn, err)
+			return
+		}
+
+		err = conn.WriteJSON(game.Players)
+
+		if err != nil {
+			util.LogSocketErrorAndCloseConnection(conn, err)
+			return
+		}
+	}
+}
+

--- a/handlers/util/buildHandler.go
+++ b/handlers/util/buildHandler.go
@@ -9,7 +9,7 @@ import (
 // and subsequently performs the action() function
 func BuildHandler(
 	requestBody interface{},
-	action func(w http.ResponseWriter, queries QueryExtractor),
+	action http.HandlerFunc,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if requestBody != nil {
@@ -28,6 +28,6 @@ func BuildHandler(
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Add("Content-Type", "application/json")
 
-		action(w, QueryExtractor{values: r.URL.Query()})
+		action(w, r)
 	}
 }

--- a/handlers/util/getQuery.go
+++ b/handlers/util/getQuery.go
@@ -2,15 +2,11 @@ package util
 
 import (
 	"errors"
-	"net/url"
+	"net/http"
 )
 
-type QueryExtractor struct {
-	values url.Values
-}
-
-func (extractor *QueryExtractor) Query(query string) (string, error) {
-	valueList := extractor.values[query]
+func GetQuery(r *http.Request, query string) (string, error) {
+	valueList := r.URL.Query()[query]
 
 	if len(valueList) == 0 {
 		return "", errors.New("Query not found: missing \"" + query + "\" query in the URL")

--- a/handlers/util/handlerLogger.go
+++ b/handlers/util/handlerLogger.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"github.com/gorilla/websocket"
 	"log"
 	"net/http"
 )
@@ -8,4 +9,25 @@ import (
 func LogInternalError(w http.ResponseWriter, err error) {
 	log.Println(err.Error())
 	http.Error(w, "Error: "+err.Error(), http.StatusBadRequest)
+}
+
+type SocketError struct {
+	Message string `json:"message"`
+}
+
+func LogSocketErrorAndCloseConnection(conn *websocket.Conn, err error) {
+	log.Println(err.Error())
+	err = conn.WriteJSON(SocketError{
+		Message: err.Error() + ", closing socket connection",
+	})
+
+	if err != nil {
+		log.Println(err.Error())
+	}
+
+	err = conn.Close()
+
+	if err != nil {
+		log.Println(err.Error())
+	}
 }

--- a/routers/routes.go
+++ b/routers/routes.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"github.com/bkach/truco/handlers"
+	"github.com/bkach/truco/handlers/sockets"
 	"github.com/gorilla/mux"
 	"net/http"
 )
@@ -23,10 +24,6 @@ func BuildRouter() *mux.Router {
 	// Gets games
 	api.HandleFunc("/games", handlers.GetGamesHandler())
 
-	// Gets games - via socket connection!
-	// This will return the list of games only if there is an update to any of the games
-	api.HandleFunc("/gamesSocket", handlers.GetGamesSocketHandler())
-
 	// Creates a player, query needs a game_id and a name for the player
 	api.HandleFunc("/createPlayer", handlers.CreatePlayerHandler())
 
@@ -41,6 +38,16 @@ func BuildRouter() *mux.Router {
 
 	// The route below serves the frontend
 	router.PathPrefix("/").Handler(http.FileServer(http.Dir("frontend/build/")))
+
+	// Socket connections
+	//
+	// These endpoints only emit data if there has been a likely change to their data
+
+	// Gets a list of games via socket connection
+	api.HandleFunc("/gamesSocket", sockets.GetGameListSocketHandler())
+
+	// Gets a list of players via socket connection
+	api.HandleFunc("/playersSocket", sockets.GetPlayerListSocketHandler())
 
 	return router
 }

--- a/truco/actions.go
+++ b/truco/actions.go
@@ -20,7 +20,7 @@ func CreateGameAndAddToGames(name string) (*Game, error) {
 
 	Games = append(Games, *newGame)
 
-	notifyGameChangeListeners()
+	notifyGameListChangeListeners()
 
 	return newGame, nil
 }
@@ -34,13 +34,9 @@ func DeleteGame(gameId string) error {
 
 	Games = append(Games[:index], Games[index+1:]...)
 
-	notifyGameChangeListeners()
+	notifyGameListChangeListeners()
 
 	return nil
-}
-
-func NumGames() int {
-	return len(Games)
 }
 
 func FindGameWithId(id string) (int, *Game, error) {
@@ -98,7 +94,7 @@ func CreatePlayer(gameId string, name string) (*Player, error) {
 
 	Games[gameIndex] = *game
 
-	notifyGameChangeListeners()
+	notifyPlayerListChangeListeners(gameId)
 
 	return newPlayer, nil
 }
@@ -120,7 +116,7 @@ func DeletePlayer(gameId string, playerId string) error {
 
 	Games[gameIndex].Players = append(players[:playerIndex], players[playerIndex+1:]...)
 
-	notifyGameChangeListeners()
+	notifyPlayerListChangeListeners(gameId)
 
 	return nil
 }
@@ -169,7 +165,7 @@ func PlayCard(gameId string, playerId string, card Card) error {
 
 	Games[gameIndex] = newGame
 
-	notifyGameChangeListeners()
+	notifyPlayerListChangeListeners(gameId)
 
 	return nil
 }
@@ -202,25 +198,8 @@ func DealCards(gameId string) error {
 
 	Games[gameIndex] = updatedGame
 
-	notifyGameChangeListeners()
+	notifyPlayerListChangeListeners(gameId)
 
 	return nil
 }
 
-func RegisterGameChangeListener(id string, onGameChange func()) {
-	gameChangeListeners[id] = GameChangeListener{
-		onGameChanged: onGameChange,
-	}
-}
-
-func RemoveGameChangeListener(id string) {
-	delete(gameChangeListeners, id)
-}
-
-// Notifies all game change listener that there has been a change in any of our games
-// TODO: Optimization: Only allow subscriptions per-game
-func notifyGameChangeListeners() {
-	for _, listener := range gameChangeListeners {
-		listener.onGameChanged()
-	}
-}

--- a/truco/card.go
+++ b/truco/card.go
@@ -2,6 +2,7 @@ package truco
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 )
 
@@ -41,15 +42,13 @@ func findCardIndex(cards []Card, card Card) (int, error) {
 			return i, nil
 		}
 	}
-	return -1, errors.New("cannot find card")
+
+	msg := fmt.Sprintf("\nError: Cannot find card %+v", card)
+	return -1, errors.New(msg)
 }
 
 func removeCard(c []Card, i int) []Card {
 	return append((c)[:i], (c)[i+1:]...)
-}
-
-func addCard(cards []Card, card Card) []Card {
-	return append(cards, card)
 }
 
 func popRandomCard(cards []Card) ([]Card, Card) {

--- a/truco/game_test.go
+++ b/truco/game_test.go
@@ -440,8 +440,7 @@ func Test_PlayCard_SameTime_HasError(t *testing.T) {
 	}
 }
 
-// TODO: This could be split into much smaller tests
-func Test_GameChangeListener_WorksAsExpected(t *testing.T) {
+func Test_GameListChangeListener_WorksAsExpected(t *testing.T) {
 	debugOn = true
 
 	id1 := "gameChangeListenerId1"
@@ -450,11 +449,11 @@ func Test_GameChangeListener_WorksAsExpected(t *testing.T) {
 	id2 := "gameChangeListenerId2"
 	listener2Counter := 0
 
-	RegisterGameChangeListener(id1, func() {
+	RegisterGameListChangeListener(id1, func() {
 		listener1Counter++
 	})
 
-	RegisterGameChangeListener(id2, func() {
+	RegisterGameListChangeListener(id2, func() {
 		listener2Counter++
 	})
 
@@ -464,44 +463,20 @@ func Test_GameChangeListener_WorksAsExpected(t *testing.T) {
 	assert.Equal(t, 1, listener1Counter)
 	assert.Equal(t, 1, listener2Counter)
 
-	player, err := CreatePlayer(game.Id, "boris")
+	err = DeleteGame(game.Id)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 2, listener1Counter)
 	assert.Equal(t, 2, listener2Counter)
 
-	err = DealCards(game.Id)
-	assert.NoError(t, err)
-
-	assert.Equal(t, 3, listener1Counter)
-	assert.Equal(t, 3, listener2Counter)
-
-	err = PlayCard(game.Id, "player_boris", Card{Value: 1, House: "gold"})
-	assert.NoError(t, err)
-
-	assert.Equal(t, 4, listener1Counter)
-	assert.Equal(t, 4, listener2Counter)
-
-	err = DeletePlayer(game.Id, player.Id)
-	assert.NoError(t, err)
-
-	assert.Equal(t, 5, listener1Counter)
-	assert.Equal(t, 5, listener2Counter)
-
-	err = DeleteGame(game.Id)
-	assert.NoError(t, err)
-
-	assert.Equal(t, 6, listener1Counter)
-	assert.Equal(t, 6, listener2Counter)
-
-	RemoveGameChangeListener(id2)
-	assert.Equal(t, 1, len(gameChangeListeners))
+	RemoveGameListChangeListener(id2)
+	assert.Equal(t, 1, len(gamesListChangeListeners))
 
 	_, err = CreateGameAndAddToGames("game0")
 	assert.NoError(t, err)
 
-	assert.Equal(t, 7, listener1Counter)
-	assert.Equal(t, 6, listener2Counter)
+	assert.Equal(t, 3, listener1Counter)
+	assert.Equal(t, 2, listener2Counter)
 }
 
 func cleanup(t *testing.T) {

--- a/truco/globalState.go
+++ b/truco/globalState.go
@@ -1,10 +1,14 @@
 package truco
 
-type GameChangeListener struct {
-	onGameChanged func()
+type Listener struct {
+	gameId string
+	onChange func()
 }
 
 // Global state
 var Games []Game
-var gameChangeListeners = map[string]GameChangeListener{}
 var debugOn = false
+
+var gamesListChangeListeners = map[string]Listener{}
+var gameChangeListeners = map[string]Listener{}
+var playerListChangeListeners = map[string]Listener{}

--- a/truco/listeners.go
+++ b/truco/listeners.go
@@ -1,0 +1,59 @@
+package truco
+
+func RegisterGameListChangeListener(id string, onChange func()) {
+	gamesListChangeListeners[id] = Listener{
+		onChange: onChange,
+	}
+}
+
+func RegisterGameChangeListener(id string, gameId string, onChange func()) {
+	gameChangeListeners[id] = Listener{
+		gameId: gameId,
+		onChange: onChange,
+	}
+}
+
+func RegisterPlayerListChangeListener(id string, gameId string, onChange func()) {
+	playerListChangeListeners[id] = Listener{
+		gameId: gameId,
+		onChange: onChange,
+	}
+}
+
+// Removes listeners
+
+func RemoveGameListChangeListener(id string) {
+	delete(gamesListChangeListeners, id)
+}
+
+func RemoveGameChangeListener(id string) {
+	delete(gameChangeListeners, id)
+}
+
+func RemovePlayerListChangeListener(id string) {
+	delete(playerListChangeListeners, id)
+}
+
+// Notifies listener
+
+func notifyGameListChangeListeners() {
+	for _, listener := range gamesListChangeListeners {
+		listener.onChange()
+	}
+}
+
+func notifyGameChangeListeners(gameId string) {
+	for _, listener := range gameChangeListeners {
+		if listener.gameId == gameId {
+			listener.onChange()
+		}
+	}
+}
+
+func notifyPlayerListChangeListeners(gameId string) {
+	for _, listener := range playerListChangeListeners {
+		if listener.gameId == gameId {
+			listener.onChange()
+		}
+	}
+}


### PR DESCRIPTION
This PR adds two socket connections:

`/api/gamesSocket/`

and

`/api/playersSocket`

Which returns a list of games and a list of players respectively. Sockets will only emit values when there is a _probable_ change in the data.